### PR TITLE
Force C standard to gnu89 for linux builds

### DIFF
--- a/src/BuildUnix.cmake
+++ b/src/BuildUnix.cmake
@@ -9,7 +9,7 @@
 message (STATUS "Building Linux version")
 
 # Static where possible (i.e. only not on the APPLE)
-set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static -m32")
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu89 -static -m32")
 
 set (scythername "scyther-linux")
 add_executable (${scythername} ${Scyther_sources})


### PR DESCRIPTION
On new gcc versions the gnu11 C standard is used by default. However your code will not compile with gnu11, as some changes for inlining functions were made. So you explictly have to force gcc to use gnu89 instead.
You might want to consider to also change this for other Platforms (I only know about linux).