### PR TITLE
Minor fix: check if ~/bin exists before copying scyther-linux

### DIFF
--- a/src/build-debug.sh
+++ b/src/build-debug.sh
@@ -18,8 +18,10 @@ echo "Built the Linux binary"
 cp scyther-linux ../gui/Scyther/
 
 # bonus...
-cp scyther-linux ~/bin
+if [ -d ~/bin  ] ; then
+  cp scyther-linux ~/bin/
+fi
 
-echo Copied the file to the gui directory and \~/bin
+echo "Copied the file to the gui directory and \~/bin (if present)"
 echo "---------------------------------------------------------"
 

--- a/src/subbuild-unix-unix.sh
+++ b/src/subbuild-unix-unix.sh
@@ -15,8 +15,10 @@ echo "Built the Linux binary"
 cp scyther-linux ../gui/Scyther/
 
 # bonus...
-cp scyther-linux ~/bin
+if [ -d ~/bin ] ; then
+  cp scyther-linux ~/bin/
+fi
 
-echo Copied the file to the gui/Scyther directory and \~/bin
+echo "Copied the file to the gui/Scyther directory and ~/bin (if present)"
 echo "---------------------------------------------------------"
 


### PR DESCRIPTION
The current behavior creates a file named ~/bin if ~/bin/ does not exist, which is a bit weird.
I propose to check whether ~/bin exist before attempting the copy.
Another solution would have been to create the directory ~/bin before attempting the copy.