### PR TITLE
Explicitly require Python 2 in describe-version.py

### DIFF
--- a/src/describe-version.py
+++ b/src/describe-version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 """
   Scyther : An automatic verifier for security protocols.
   Copyright (C) 2007-2013 Cas Cremers


### PR DESCRIPTION
`python` is the OS' default, which is Python 2 on most systems, but not all of them, such as Arch Linux by default.