### PR TITLE
Have build scripts fail on first failing command

### DIFF
--- a/src/subbuild-mac-intel.sh
+++ b/src/subbuild-mac-intel.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # Default flags
 CMFLAGS="-D CMAKE_BUILD_TYPE:STRING=Release"
 

--- a/src/subbuild-unix-unix.sh
+++ b/src/subbuild-unix-unix.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 # Default flags
 CMFLAGS="-D CMAKE_BUILD_TYPE:STRING=Release"
 

--- a/src/subbuild-unix-w32.sh
+++ b/src/subbuild-unix-w32.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e 
+
 # Default flags
 CMFLAGS="-D CMAKE_BUILD_TYPE:STRING=Release"
 


### PR DESCRIPTION
This avoids spurious errors from trying to copy files that weren't built, and mimics the behavior of other build systems