### PR TITLE
Closes #30, enabling builds on Windows under MSYS2 per instructions in Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ If you are using Ubuntu, installing these may be as simple as running
 In case you also want to be able to compile Windows binaries from Linux,
 you also need:
 
-  * `mingw32`
+  * `i686-w64-mingw32`
 
 Note that welcome all contributions, e.g., further protocol models. Just send
 us a pull request.

--- a/src/Build-Win32.cmake
+++ b/src/Build-Win32.cmake
@@ -1,0 +1,22 @@
+################################################################
+# Name:		BuildUnix-Win32.cmake
+# Purpose:	Build Win32 binary on Unix
+# Author:	Cas Cremers
+################################################################
+
+message (STATUS "Building W32 version")
+
+# This should work on win32 platform, but also when the compiler
+# is available anyway under linux
+set (CMAKE_C_COMPILER "i686-w64-mingw32-gcc")
+set (CMAKE_CXX_COMPILER "i686-w64-mingw32-g++")
+set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)	# to get rid of -rdynamic
+# Signal for windows
+set (CMAKE_C_FLAGS "-DFORWINDOWS")
+
+# Static where possible (i.e. only not on the APPLE)
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -static -m32")
+
+set (scythername "scyther-w32.exe")
+add_executable (${scythername} ${Scyther_sources})
+

--- a/src/BuildUnix-Win32.cmake
+++ b/src/BuildUnix-Win32.cmake
@@ -8,8 +8,8 @@ message (STATUS "Building W32 version")
 
 # This should work on win32 platform, but also when the compiler
 # is available anyway under linux
-set (CMAKE_C_COMPILER "i586-mingw32msvc-gcc")
-set (CMAKE_CXX_COMPILER "i586-mingw32msvc-g++")
+set (CMAKE_C_COMPILER "i686-w64-mingw32-gcc")
+set (CMAKE_CXX_COMPILER "i686-w64-mingw32-g++")
 set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)	# to get rid of -rdynamic
 # Signal for windows
 set (CMAKE_C_FLAGS "-DFORWINDOWS")


### PR DESCRIPTION
Supercedes #31 which included an extraneous commit.